### PR TITLE
bump ts-node to version 3 for app template-frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "redux": "^3.7.0",
     "redux-actions": "^2.0.3",
     "redux-devtools-extension": "^2.13.2",
-    "ts-node": "^2.1.0",
+    "ts-node": "^3.1.0",
     "typescript": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
newly released typescript package v2.4.1 is not working so we're bumping ts-node to version 3 to fix it
Context:
Microsoft/TypeScript#16772