### PR TITLE
Bump frontend-utils version to 1.2.1 minimum to get bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "body-parser": "^1.17.0",
     "clever-components": "1.8.0",
     "clever-discovery": "0.0.8",
-    "clever-frontend-utils": "^1.1.0",
+    "clever-frontend-utils": "^1.2.1",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.4.1",


### PR DESCRIPTION
There was a bug in clever-frontend-utils with AsyncListReducers that was fixed in version 1.2.1. This bumps the version in the package.json to make sure the new fixed version gets pulled in.