### PR TITLE
Remove Function type which can cause components to accept non-existent props

### DIFF
--- a/types/function/index.d.ts
+++ b/types/function/index.d.ts
@@ -1,5 +1,0 @@
-// Remove when we have real types.
-interface Function {
-  propTypes: any;
-  defaultProps: any;
-}


### PR DESCRIPTION
## Overview
I noticed in Launchpad that our Function interface extension can allow non-existent props to be passed into components https://github.com/Clever/launchpad/pull/2991

Let's remove it from template-frontend as well!