### PR TITLE
move to circle workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,75 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  common-executor:
     working_directory: ~/Clever/{{.AppName}}
     docker:
     - image: circleci/node:12-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+
+commands:
+  clone-ci-scripts:
+    description: Clone the ci-scripts repo
     steps:
     - run:
-        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+        command: cd .. && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
         name: Clone ci-scripts
+
+jobs:
+  build:
+    executor: common-executor
+    steps:
     - checkout
-    - setup_remote_docker
-    - run:
-        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-        name: Set up CircleCI artifacts directories
     - run:
         command: npm install
         name: npm install
     - run: NODE_ENV=production make build
+    - persist_to_workspace:
+        root: ~/Clever
+        paths: "."
+
+  publish:
+    executor: common-executor
+    steps:
+    - attach_workspace:
+        at: ~/Clever
+    - clone-ci-scripts
+    - setup_remote_docker
+    - run: ../ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
+    - run: ../ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS {{.AppName}}
+
+  unit-test:
+    executor: common-executor
+    steps:
+    - attach_workspace:
+        at: ~/Clever
+    - run:
+        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+        name: Set up CircleCI artifacts directories
     - run: make lint
-    - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS {{.AppName}}
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev no-confirm-deploy; fi;
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy; fi;
+    - run: make test
+  
+  deploy:
+    executor: common-executor
+    steps:
+    - clone-ci-scripts
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then ../ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME clever-dev no-confirm-deploy; fi;
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then ../ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME production confirm-then-deploy; fi;
+
+workflows:
+  version: 2.1
+  build_test_publish_deploy:
+    jobs:
+    - build
+    - unit-test:
+        requires:
+        - build
+    - publish:
+        requires:
+        - build
+    - deploy:
+        requires:
+        - unit-test
+        - publish

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Clever/{{.TeamName}}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,7 @@
 ## Testing
 
 ## Rollout
+
+## New Repo Setup
+- [ ] Set up Slack notifications for this app for your team https://clever.atlassian.net/wiki/spaces/ENG/pages/888897571/GitHub+assignments
+- [ ] Delete this section from the PR template


### PR DESCRIPTION
## Link to JIRA
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-3723)

## Overview
Let's move new repos to use this workflow-style Circle config. Some advantages are that publishing can happen at the same time as testing, and that it is easier to rerun individual pieces when there are failures.

Based on https://github.com/Clever/cil-event-logs-service/pull/102

-----
Also adding CODEOWNERS for autoassignment, and some "first-time" steps to the PR template.