### PR TITLE
SEC-810 Add CSRF middleware

### DIFF
--- a/src/server/app/app.ts
+++ b/src/server/app/app.ts
@@ -11,6 +11,7 @@ import { installApiEndpoints } from "src/server/api";
 import { installAuthEndpoints } from "src/server/auth";
 import { LandingPageEndpoint } from "src/server/pages";
 import { PORT } from "../../../config";
+import { csrfProtectionMiddleware } from "../middleware";
 
 export function startServer() {
   const app = express();
@@ -36,6 +37,9 @@ export function startServer() {
   });
 
   Clients.initialize();
+
+  // Run CSRF middleware before routing for other endpoints
+  app.use(csrfProtectionMiddleware);
 
   installAuthEndpoints(app);
   installApiEndpoints(app);

--- a/src/server/lib/helpers.ts
+++ b/src/server/lib/helpers.ts
@@ -1,0 +1,16 @@
+import * as url from "url";
+
+/**
+ * TODO: This helper function may not work for proxy-fronted
+ * services (see launchpad fronted by clever-com-router),
+ * so replace code as needed to retrieve URL correctly.
+ */
+export function getAppURL() {
+  const isLocal = process.env.HOST === "localhost";
+  const appURL = url.format({
+    protocol: isLocal ? "http" : "https",
+    hostname: process.env.HOST,
+    port: isLocal ? process.env.PORT : undefined,
+  });
+  return appURL;
+}

--- a/src/server/middleware/csrfProtectionMiddleware.ts
+++ b/src/server/middleware/csrfProtectionMiddleware.ts
@@ -1,0 +1,48 @@
+import * as url from "url";
+const { getAppURL } = require("../lib/helpers");
+
+/**
+ * CSRF protection - ensure that state changing requests originate from us (our origin) or, as a
+ * fallback, that the referer's host matches. This is based on the recommendations here:
+ * https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+ *
+ * CSRF protection verifies that the request originates from a place we expect.
+ * Defining it as middleware that's applied before every request ensures
+ * the check fires off before we route anywhere in the application.
+ *
+ * TODO: Add this middleware to an external library, and refactor existing frontend
+ * applications to use the library middleware instead of their unique CSRF middleware.
+ */
+export const csrfProtectionMiddleware = (req, res, next) => {
+    if (["POST", "PATCH", "DELETE", "PUT"].includes(req.method)) {
+      const parsedAppURL = url.parse(getAppURL());
+      const expectedOrigin = `${parsedAppURL.protocol}//${parsedAppURL.host}`;
+
+      if (req.headers.origin) {
+        if (req.headers.origin === expectedOrigin) {
+          next();
+          return;
+        }
+      } else if (typeof req.headers.referer === "string") {
+        // IE11 and Edge do not send origin headers by default for same-origin requests, so fall
+        // back to the referer.
+        const { host, protocol } = url.parse(req.headers.referer);
+        if (`${protocol}//${host}` === expectedOrigin) {
+          next();
+          return;
+        }
+      }
+      /** TODO: Log CSRF failure 
+      logger.warnD("csrf_failure", {
+        method: req.method,
+        url: req.url,
+        origin: req.headers.origin,
+        referer: req.headers.referer,
+        agent: req.headers["user-agent"],
+      });
+      */
+      res.sendStatus(403);
+    } else {
+      next();
+    }
+};

--- a/src/server/middleware/index.ts
+++ b/src/server/middleware/index.ts
@@ -1,2 +1,3 @@
 export * from "./endpointTypeMiddleware";
 export * from "./userLoggedInMiddleware";
+export * from "./csrfProtectionMiddleware";


### PR DESCRIPTION
## Link to JIRA
[SEC-810](https://clever.atlassian.net/browse/SEC-810)

## Overview
Add CSRF protection middleware (using origin checking) to frontend-template as follow for [FLARE-827](https://clever.atlassian.net/browse/FLARE-827)

## Testing
tested by doing the following:
- initialized a new app with ark using the existing frontend-template, manually copied over the [csrf middleware changes](https://github.com/Clever/frontend-csrf-test-app/compare/csrf-middleware-testing) that are in this PR, and deployed the app to a dev environment with a `int.clever.com` domain. 
- created two routes to `GET` and `POST` where get would increment a counter variable that was kept in a user session with [express-session](https://www.npmjs.com/package/express-session).
- created a simple web page app hosted externally by [ngrok](https://ngrok.com/), and created a button that would link to the `POST` url above, and verified that clicking the button would result in a 403 forbidden failure, and log the csrf failure 
- tested against chrome, firefox, and edge (since IE11 and Edge do not send origin headers by default, the csrf check is handled differently) 
![Screen Recording 2020-03-02 at 06 27 PM](https://user-images.githubusercontent.com/10677803/75736976-88aa8780-5cb3-11ea-9d7c-047da30262f2.gif)
log produced by above action ^: `Tue 02:26:31.741 frontend-csrf-test-app/2b6e13b8~> { source.title=frontend-csrf-test-app.csrf_failure, agent:"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36", method:"POST", origin:"http://d5a8bdeb.ngrok.io", referer:"http://d5a8bdeb.ngrok.io/", url:"/test-post" }`
## Rollout
