### PR TITLE
Get template running again

### DIFF
--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -1,2 +1,2 @@
-# see go/log-routing for details
-routes:
+# See go/log-routing for details
+routes: {}

--- a/launch/template-frontend.yml
+++ b/launch/template-frontend.yml
@@ -14,9 +14,9 @@ expose:
     type: http
     path: /_healthcheck
 team: "{{.TeamName}}"
-# for the full spec on alarms, see catapult's swagger.yml definition for Alarm
-#    link: https://github.com/Clever/catapult/blob/master/swagger.yml
-#    best practices: https://clever.atlassian.net/wiki/spaces/~620990898/pages/904036784/Alarm+Best+Practices
+# For the full spec on alarms, see catapult's swagger.yml definition for Alarm.
+# Link: https://github.com/Clever/catapult/blob/master/swagger.yml
+# Best practices: https://clever.atlassian.net/wiki/spaces/~620990898/pages/904036784/Alarm+Best+Practices
 alarms:
 - type: InternalErrorAlarm
   severity: critical

--- a/package-lock.json
+++ b/package-lock.json
@@ -5604,6 +5604,61 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-loader": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.0.tgz",
+      "integrity": "sha512-26qPdHyTsArQ6gU4P1HJbAbnFTyT2r0pG7czh1GFAd9TZbj0n94wWbupgixZH/ET/meqi2/5+F7DhW4OAXD+Lg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.7.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react": "^7.21.3",
     "eslint-plugin-react-hooks": "^4.1.2",
     "extract-text-webpack-plugin": "^2.0.0",
+    "file-loader": "^6.1.0",
     "jest": "^26.5.2",
     "less-loader": "^2.2.3",
     "nodemon": "^1.11.0",

--- a/src/server/app/app.ts
+++ b/src/server/app/app.ts
@@ -18,7 +18,7 @@ export function startServer() {
   // env vars are guaranteed by our deployment system
   const isLocal = process.env._IS_LOCAL === "true";
   const logger = new kayvee.logger(process.env._APP_NAME);
-  kayvee.setGlobalRouting(path.join(__dirname, "kvconfig.yml"));
+  kayvee.setGlobalRouting(path.join(__dirname, "..", "..", "..", "kvconfig.yml"));
 
   const app = express();
   patchExpressForPromises(app);


### PR DESCRIPTION
I noticed a few errors when trying to run the template via `make run` (what `ark start -l` calls under the hood).

On the server:

```
Error: ENOENT: no such file or directory, open '/Users/arsalan/go/src/github.com/Clever/template-frontend/src/server/app/kvconfig.yml'
```

On the client:

```
ERROR in ./node_modules/react-linkify/dist/Linkify.js
Module not found: Error: Can't resolve 'file-loader' in '/Users/arsalan/go/src/github.com/Clever/template-frontend'
```

This PR addresses both of the above to get the template running again.