### PR TITLE
Make it easier to load/mock clients/libs on the Clients class

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,1 +1,2 @@
+export const IS_TEST = Boolean(process.env.TEST);
 export const PORT = process.env.PORT || 5020;

--- a/src/server/lib/Clients.ts
+++ b/src/server/lib/Clients.ts
@@ -1,3 +1,30 @@
+// A fake WAG client. Included to demonstrate what it looks like to load a WAG client onto this
+// class.
+// import * as SpongeBobService from "@clever/spongebob-service";
+
+import { KrabbyPattyLib } from "./krabbyPatties/KrabbyPattyLib";
+import * as config from "src/server/config";
+
+// A mock for the fake WAG client
+class SpongeBobService {
+  constructor(options: DiscoveryOptions) {
+    return;
+  }
+}
+
+interface DiscoveryOptions {
+  discovery: true;
+}
+
+function constructWagClientOptions(): DiscoveryOptions {
+  return { discovery: true };
+}
+
+class ClientDefinitions {
+  static krabbyPattyLib: KrabbyPattyLib;
+  static spongeBobService: SpongeBobService;
+}
+
 /**
  * The Clients class is intended to simplify the process of passing dependencies (backend clients
  * and frontend server libs) around the server codebase.
@@ -6,47 +33,27 @@
  * constructor params, we can load everything onto the Clients class. Endpoint handlers and libs
  * can then import this one class for access to all needed dependencies.
  */
+export class Clients extends ClientDefinitions {
+  static initialize(overrides: PartialClientsMap = {}) {
+    if (config.IS_TEST) {
+      Object.assign(this, overrides);
+      return;
+    }
 
-// A fake WAG client. Included to demonstrate what it looks like to load a WAG client onto this
-// class.
-// import * as SpongeBobService from "@clever/spongebob-service";
-
-import { KrabbyPattyLib } from "./krabbyPatties/KrabbyPattyLib";
-
-interface ClientMap {
-  krabbyPattyLib?: any;
-  spongeBobService?: any;
-}
-
-export class Clients {
-  static _krabbyPattyLib: KrabbyPattyLib;
-  static _spongeBobService: any;
-
-  static constructWagClientOptions() {
-    return {};
-  }
-
-  static initialize() {
-    const krabbyPattyLib = new KrabbyPattyLib();
-
-    // const spongeBobService = new SpongeBobService(this.constructWagClientOptions());
-
-    this.loadClients({
-      krabbyPattyLib,
-      // spongeBobService,
-    });
-  }
-
-  static loadClients(clients: ClientMap) {
-    this._krabbyPattyLib = clients.krabbyPattyLib;
-    this._spongeBobService = clients.spongeBobService;
-  }
-
-  static get krabbyPattyLib(): KrabbyPattyLib {
-    return this._krabbyPattyLib;
-  }
-
-  static get spongeBobService() {
-    return this._spongeBobService;
+    this.krabbyPattyLib = new KrabbyPattyLib();
+    this.spongeBobService = new SpongeBobService(constructWagClientOptions());
+    Object.assign(this, overrides);
   }
 }
+
+// The Omit is necessary since typeof ClientDefinitions includes a prototype field we want to
+// exclude.
+type ClientsMap = Omit<typeof ClientDefinitions, "prototype">;
+
+/**
+ * An object where all clients can optionally be present and all methods of a client are optional.
+ * Ideal for passing in mocks of clients.
+ */
+type PartialClientsMap = Partial<
+  { [clientKey in keyof ClientsMap]: Partial<ClientsMap[clientKey]> }
+>;


### PR DESCRIPTION
This PR makes it easier to load/mock clients/libs on the Clients class, while also maintaining good typing. It's a port of https://github.com/Clever/family-portal/pull/22. See that PR for more context!