### PR TITLE
Update global middlewares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,6 +2469,11 @@
         "@types/jest": "*"
       }
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "integrity": "sha512-ngUKcHnytUodUCL7C6EZ+lVXUjTMQb+9p/e1JjV5tN9TVzS98lHozWEFRPY1QcCdwFeMsmVWfZ3DPPT/udCyIw=="
+    },
     "@types/uglify-js": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react-dom": "^16.9.8",
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.6",
+    "@types/ua-parser-js": "^0.7.33",
     "body-parser": "^1.19.0",
     "clever-components": "^2.62.5",
     "clever-discovery": "^0.0.8",
@@ -31,6 +32,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "ts-node": "^9.0.0",
+    "ua-parser-js": "^0.7.22",
     "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -25,7 +25,7 @@ function discoveryWrapper(service: string, expose: string, method: string) {
   }
 }
 
-export const APP_NAME = process.env._APP_NAME; // Provided by deployment system
+export const APP_NAME = process.env._APP_NAME || "{{.AppName}}"; // Provided by deployment system
 export const HOST = process.env.HOST || "localhost";
 export const PORT = Number(process.env.PORT) || 5020;
 

--- a/src/server/lib/logging/index.ts
+++ b/src/server/lib/logging/index.ts
@@ -1,0 +1,1 @@
+export * from "./requestExtractors";

--- a/src/server/lib/logging/requestExtractors.ts
+++ b/src/server/lib/logging/requestExtractors.ts
@@ -1,0 +1,36 @@
+import * as express from "express";
+import { UAParser } from "ua-parser-js";
+
+export const extractFieldsFromRequest = (req: express.Request) => ({
+  ...extractIdentifiers(req),
+  ...extractRouteDetails(req),
+  ...extractUserAgentDetails(req),
+});
+
+export function extractIdentifiers(req: express.Request) {
+  return {
+    // TODO: Add relevant user identifiers, like session ID and user ID
+  };
+}
+
+export function extractRouteDetails(req: express.Request) {
+  return {
+    method: req.method, // GET
+    path: req.path, // /users/1234
+    route: req.route && req.route.path, // /users/:id
+  };
+}
+
+export function extractUserAgentDetails(req: express.Request) {
+  const uaParser = new UAParser(req.headers["user-agent"]);
+  const ua = uaParser.getResult();
+
+  return {
+    ua_browser: ua.browser && ua.browser.name,
+    ua_browser_version: ua.browser && ua.browser.version,
+    ua_device: ua.device && ua.device.model,
+    ua_device_type: ua.device && ua.device.type,
+    ua_os: ua.os && ua.os.name,
+    ua_os_version: ua.os && ua.os.version,
+  };
+}

--- a/src/server/middleware/bodyParserErrorHandler.ts
+++ b/src/server/middleware/bodyParserErrorHandler.ts
@@ -1,0 +1,25 @@
+import * as express from "express";
+
+/**
+ * Takes a body parser middleware as input and returns a middleware that wraps the body parser,
+ * but handles any user errors so that they don't get reported, e.g. to Sentry.
+ */
+export function bodyParserErrorHandler(bodyParserMiddleware: express.Handler): express.Handler {
+  return (req, res, next) => {
+    // Call the original middleware, but handle its errors
+    bodyParserMiddleware(req, res, (err: any) => {
+      if (err) {
+        // For a user error (4XX), immediately respond with the status and message
+        if (err.status && err.status >= 400 && err.status < 500) {
+          res.status(err.status).send(err.message || "");
+          return;
+        }
+        // For other errors, use the regular error handler so that the errors get reported, e.g. to
+        // Sentry
+        next(err);
+        return;
+      }
+      next();
+    });
+  };
+}


### PR DESCRIPTION
This PR updates the template-frontend's global middlewares, porting over a number of changes from FamPo. These updates include:

- Handling errors from the body-parser middleware (https://github.com/Clever/family-portal/pull/104)
- Configuring the health check as a short-circuiting middleware (a common practice in our frontend servers to ensure that the health check is as lightweight as possible) (part of https://github.com/Clever/family-portal/pull/88)
- Adding a middleware to auto-redirect from http to https (unless running locally) (https://github.com/Clever/family-portal/pull/88)
- Adding a middleware to handle malformed paths (https://github.com/Clever/family-portal/pull/107)
- Adding Kayvee middleware for request-finished logs and a `req.log` logger (https://github.com/Clever/family-portal/pull/18/commits/df60ed38a9a8988f0a64e2988d0d96b2479eb64f)

The PR also sets `trust proxy` to `true`, which is necessary because our Node servers don't terminate TLS themselves; our ELBs do (a port of https://github.com/Clever/family-portal/pull/21 but also mentioned in https://github.com/Clever/family-portal/pull/88).

