### PR TITLE
Grant CircleCI the ability to install private dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ jobs:
     executor: common-executor
     steps:
       - checkout
+      - run:
+          name: Set up .npmrc
+          command: |
+            sed -i.bak s/\${npm_auth_token}/$NPM_TOKEN/ .npmrc_docker
+            mv .npmrc_docker .npmrc
       - run: npm install
       - run:
           name: Build assets

--- a/.npmrc_docker
+++ b/.npmrc_docker
@@ -1,0 +1,5 @@
+ca = null
+//registry.npmjs.org/:_authToken=${npm_auth_token}
+@clever:registry=https://registry.npmjs.org/
+always-auth = true
+strict-ssl = true


### PR DESCRIPTION
For every new frontend repo, we have to make some tweaks to grant CircleCI the ability to install private dependencies, e.g. https://github.com/Clever/family-portal/commit/9fbb55f7251d24a99163d79b35c9f3fc57dfdab2. Let's bake these tweaks into the template so that engineers don't have to make them.

The tweaks mirror Infra's [instructions here](https://clever.atlassian.net/wiki/spaces/ENG/pages/106566084/Build+System#BuildSystem-Installingaprivatepackage).