### PR TITLE
Use typed discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,9 +4621,9 @@
       }
     },
     "clever-discovery": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/clever-discovery/-/clever-discovery-0.0.8.tgz",
-      "integrity": "sha1-7JqsZ5iF7XYZZQgwaYzC/S6BYPA="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/clever-discovery/-/clever-discovery-0.0.9.tgz",
+      "integrity": "sha512-ANkyqFAegD8xtoePKL+JWwTlt/XkSI83LHx6aK4y05JmgGk/EmSrKpTOGmeZ23BxEzURreHsvCAPxLKd7Q5D7A=="
     },
     "clever-frontend-utils": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/ua-parser-js": "^0.7.33",
     "body-parser": "^1.19.0",
     "clever-components": "^2.62.5",
-    "clever-discovery": "^0.0.8",
+    "clever-discovery": "^0.0.9",
     "clever-frontend-utils": "^1.6.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -14,7 +14,7 @@ export const IS_TEST = Boolean(process.env.IS_TEST);
 // In test environments, calls to discovery can fail due to undefined env vars. We swallow errors
 // in those cases.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function discoveryWrapper(service: string, expose: string, method: string) {
+function discoveryWrapper(service: string, expose: string, method: discovery.Method) {
   try {
     return discovery(service, expose)[method]();
   } catch (err) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "jsx": "react",
     "lib": ["dom", "es2019"],

--- a/types/placeholder/index.d.ts
+++ b/types/placeholder/index.d.ts
@@ -1,3 +1,2 @@
-declare module "clever-discovery";
 declare module "redux-actions";
 declare module "kayvee";


### PR DESCRIPTION
Ports the changes from https://github.com/Clever/family-portal/pull/212 to the template-frontend. Namely, it switches to using the new version of `clever-discovery` with types and removes an unnecessary `allowSyntheticDefualtImports`.