### PR TITLE
migrate single-region services to app mesh in hybrid state in dev

### DIFF
--- a/launch/template-frontend.yml
+++ b/launch/template-frontend.yml
@@ -1,58 +1,58 @@
 env:
-  - HOST
-  - PORT
+- HOST
+- PORT
 resources:
   cpu: 0.5
   max_mem: 1
 shepherds:
-  - "{{.CreatorEmail}}"
+- '{{.CreatorEmail}}'
 expose:
-  - name: http
-    port: 80
-    health_check:
-      type: http
-      path: /_healthcheck
-team: "{{.TeamName}}"
+- name: http
+  port: 80
+  health_check:
+    type: http
+    path: /_healthcheck
+team: '{{.TeamName}}'
 # For the full spec on alarms, see catapult's swagger.yml definition for Alarm.
 # Link: https://github.com/Clever/catapult/blob/master/swagger.yml
 # Best practices: https://clever.atlassian.net/wiki/spaces/~620990898/pages/904036784/Alarm+Best+Practices
 alarms:
-  - type: InternalErrorAlarm
-    severity: critical
-    parameters:
-      threshold: 0.05
-    extraParameters:
-      source: Total
-      errorMinimum: 20
-  - type: InternalErrorAlarm
-    severity: major
-    parameters:
-      threshold: 0.01
-    extraParameters:
-      source: Total
-  - type: InternalErrorAlarm
-    severity: major
-    parameters:
-      threshold: 0.002
-      evaluationPeriods: 5
-    extraParameters:
-      source: Total
-  - type: InternalErrorAlarm
-    severity: minor
-    parameters:
-      threshold: 0.001
-    extraParameters:
-      source: Total
-  - type: BadRequestAlarm
-    severity: major
-    parameters:
-      threshold: 0.15
-    extraParameters:
-      errorMinimum: 20
-  - type: BadRequestAlarm
-    severity: minor
-    parameters:
-      threshold: 0.05
+- type: InternalErrorAlarm
+  severity: critical
+  parameters:
+    threshold: 0.05
+  extraParameters:
+    source: Total
+    errorMinimum: 20
+- type: InternalErrorAlarm
+  severity: major
+  parameters:
+    threshold: 0.01
+  extraParameters:
+    source: Total
+- type: InternalErrorAlarm
+  severity: major
+  parameters:
+    threshold: 0.002
+    evaluationPeriods: 5
+  extraParameters:
+    source: Total
+- type: InternalErrorAlarm
+  severity: minor
+  parameters:
+    threshold: 0.001
+  extraParameters:
+    source: Total
+- type: BadRequestAlarm
+  severity: major
+  parameters:
+    threshold: 0.15
+  extraParameters:
+    errorMinimum: 20
+- type: BadRequestAlarm
+  severity: minor
+  parameters:
+    threshold: 0.05
 pod_config:
   group: us-west-1
 deploy_config:
@@ -60,3 +60,6 @@ deploy_config:
   autoDeployEnvs:
   - production
   - clever-dev
+mesh_config:
+  dev:
+    state: hybrid


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-5111

**Overview:**
In this PR we will migrate all internal single region services in this repo to use app mesh to hybrid state.

After this PR is merged the workers will have both envoy proxy sidecar and other appmesh constructs as well as a loadbalancers. Other services/workers have the option to use either option for making connections.

Eventually all services and workers will be restarted to make it so that all traffic comes through envoy at which point we will migrate this service to mesh_only

**Rollout:**
- monitor cpu and memory
- if upstream is in mesh then restart them so that traffic is sent using envoy
