### PR TITLE
Auth 764

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,7 @@ WORKDIR /{{.AppName}}
 COPY . /{{.AppName}}
 RUN npm install
 
+# Precompile node assets and resolve tsconfig.json paths
+RUN npx tsc && npx tsc-alias --outDir .
+
 CMD NODE_ENV=production NODE_OPTIONS="$_CLEVER_DEFAULT_NODE_OPTIONS" ./scripts/startServer.sh

--- a/Makefile
+++ b/Makefile
@@ -78,4 +78,4 @@ build: clean copy-static-assets
 	@$(WEBPACK)
 
 run: clean copy-static-assets
-	@$(WEBPACK) serve & $(NODEMON) --watch ./src/server/ --watch ./src/shared/ -e ts --exec 'NODE_ENV=development ./scripts/startServer.sh'
+	@$(WEBPACK) serve & $(NODEMON) --watch ./src/server/ --watch ./src/shared/ -e ts --exec 'NODE_ENV=development ./scripts/startDevServer.sh'

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-redux": "^7.1.9",
     "@types/react-router-dom": "^5.1.6",
     "@types/ua-parser-js": "^0.7.33",
+    "@types/ws": "8.5.4",
     "body-parser": "^1.19.0",
     "clever-components": "^2.216.0",
     "clever-discovery": "^0.0.9",
@@ -34,6 +35,7 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "ts-node": "^9.0.0",
+    "tsc-alias": "^1.8.6",
     "ua-parser-js": "^0.7.22",
     "whatwg-fetch": "^3.4.1"
   },

--- a/scripts/startDevServer.sh
+++ b/scripts/startDevServer.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+node --require ts-node/register/transpile-only --require tsconfig-paths/register ./src/server/index.ts

--- a/scripts/startServer.sh
+++ b/scripts/startServer.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-node --require ts-node/register/transpile-only --require tsconfig-paths/register ./src/server/index.ts
+node ./src/server/index.js

--- a/src/ui/store/counter.ts
+++ b/src/ui/store/counter.ts
@@ -25,7 +25,7 @@ const incrementCounterNow = () => async (dispatch: any, getState: any) => {
 };
 
 async function delay(seconds: number) {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     setTimeout(() => resolve(), seconds * 1000);
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "target": "es2019",
     "typeRoots": ["node_modules/@types", "types"]
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "jest"]
 }


### PR DESCRIPTION
# Jira
[AUTH-764](https://clever.atlassian.net/browse/AUTH-764)

# Overview
This branch uses `tsc` to precompile Typescript assets during the Docker build process.

# Testing
This is an `ark` template repo, so testing is a bit tricky. I'm using a concrete project created with the repo to test the changes. If https://github.com/Clever/infravision/pull/21 passes, this is good too.

# Rollout
:100:

[AUTH-764]: https://clever.atlassian.net/browse/AUTH-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ