### PR TITLE
migrate pod config to uw2

### DIFF
--- a/launch/template-frontend.yml
+++ b/launch/template-frontend.yml
@@ -1,17 +1,17 @@
 env:
-- HOST
-- PORT
+  - HOST
+  - PORT
 resources:
   cpu: 0.5
   max_mem: 1
 shepherds:
-- '{{.CreatorEmail}}'
+  - '{{.CreatorEmail}}'
 expose:
-- name: http
-  port: 80
-  health_check:
-    type: http
-    path: /_healthcheck
+  - name: http
+    port: 80
+    health_check:
+      type: http
+      path: /_healthcheck
 team: '{{.TeamName}}'
 # If you want to use the default alarms then delete the commented section below and catapult will set
 # them automatically for you but it is recommended that you tune the alarms based on your service needs.
@@ -48,12 +48,12 @@ team: '{{.TeamName}}'
 #   extraParameters:
 #     errorMinimum: 100
 pod_config:
-  group: us-west-1
+  group: us-west-2
 deploy_config:
   canaryInProd: true
   autoDeployEnvs:
-  - production
-  - clever-dev
+    - production
+    - clever-dev
 mesh_config:
   dev:
     state: mesh_only


### PR DESCRIPTION
**Jira:** https://clever.atlassian.net/browse/INFRANG-5936

# Overview:
This PR migrates the app to us-west-2

# Testing:

Dev:
1. Deploy in us-west-2 clever-dev or dev-infra environment (merging not mandatory)
2. Restart upstream services
3. Team owners to test if dev service is functional in us-west-2
4. Kill the older deployment in us-west-1 after confirming successful deploy and traffic flow/activity

Prod:
1. Get approval from app owners
2. Deploy in us-west-2 after merging
3. Restart upstream services
4. Traffic to pods can be verified in Grafana
5. Kill the older prod deployment in us-west-1 after a minimum of 3 days only after confirming all traffic is coming thru to the new deployment
