### PR TITLE
move to using externalUrlUsage instead of discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/ws": "8.5.5",
     "body-parser": "^1.20.2",
     "clever-components": "^2.219.0",
-    "clever-discovery": "^0.0.9",
+    "clever-discovery": "^1.1.0",
     "clever-frontend-utils": "^1.8.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,4 +1,4 @@
-import * as discovery from "clever-discovery";
+import { discovery, external_url, discoveryMethod } from "clever-discovery";
 import * as url from "url";
 
 /**
@@ -14,9 +14,21 @@ export const IS_TEST = Boolean(process.env.IS_TEST);
 // In test environments, calls to discovery can fail due to undefined env vars. We swallow errors
 // in those cases.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function discoveryWrapper(service: string, expose: string, method: discovery.Method) {
+function discoveryWrapper(service: string, expose: string, method: discoveryMethod) {
   try {
     return discovery(service, expose)[method]();
+  } catch (err) {
+    if (IS_TEST) {
+      return "";
+    }
+    throw err;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function externalUrlWrapper(url: string) {
+  try {
+    return external_url(url);
   } catch (err) {
     if (IS_TEST) {
       return "";


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6337

# Overview
CCR is going away so apps can't really depend on CCR. But today apps don't really depend on CCR, they use `discovery(clever-com-router, external)` just to build a link which is used for redirects.

Now we are moving to a new system where the links are defined in `externalUrlUsage` in launch config of the app. 

I am updating the version of clever-discovery in our template so that new repo start off with best practices. 

# Testing

This template is similar to family-portal which was tested!

#
