### PR TITLE
bump version of clever-discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/ws": "8.5.5",
     "body-parser": "^1.20.2",
     "clever-components": "^2.219.0",
-    "clever-discovery": "^1.1.0",
+    "clever-discovery": "^1.2.0",
     "clever-frontend-utils": "^1.8.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,4 +1,4 @@
-import { discovery, external_url, discoveryMethod } from "clever-discovery";
+import { discovery, external, discoveryMethod, externalMethod } from "clever-discovery";
 import * as url from "url";
 
 /**
@@ -26,9 +26,9 @@ function discoveryWrapper(service: string, expose: string, method: discoveryMeth
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function externalUrlWrapper(url: string) {
+function externalUrlWrapper(url: string, method: externalMethod) {
   try {
-    return external_url(url);
+    return external(url)[method]();
   } catch (err) {
     if (IS_TEST) {
       return "";


### PR DESCRIPTION
## JIRA
https://clever.atlassian.net/browse/INFRANG-6430

## Overview
There was a breaking api change to clever-discovery for external_url. This PR pulls in the latest version

## Testing
unit tests are good enough for this change!

## Rollout
deploy