### PR TITLE
fix: Makefile's run target to not prematurely clean the /build folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,5 +77,5 @@ copy-static-assets: clean
 build: clean copy-static-assets
 	@$(WEBPACK)
 
-run: clean copy-static-assets
+run: build
 	@$(WEBPACK) serve & $(NODEMON) --watch ./src/server/ --watch ./src/shared/ -e ts --exec 'NODE_ENV=development ./scripts/startDevServer.sh'

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "tsconfig-paths-webpack-plugin": "^3.3.0",
     "typescript": "^4.9.5",
     "url-loader": "^4.1.1",
-    "webpack": "^5.88.2",
-    "webpack-bundle-analyzer": "^4.9.1",
-    "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.15.1"
+    "webpack": "^5.99.6",
+    "webpack-bundle-analyzer": "^4.10.2",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }


### PR DESCRIPTION
# Jira
[FEE-220]

# Overview
There were two issues I encountered when using this template

`ark init -t template-frontend ...`

## Bug 1: ECONNREFUSED when trying to goto localhost
`[webpack-dev-server] [HPM] Error occurred while proxying request localhost:5020/ to http://localhost:5021/ [ECONNREFUSED] (https://nodejs.org/api/errors.html#errors_common_system_errors)`

After some digging around, it turns out newer versions of webpack-dev-server deal with 
- https://github.com/webpack/webpack-dev-server/issues/4828 
- https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705 

So the fix was to update webpack to more recent versions.

## Bug 2: Running ark start -l would delete the /build folder

.. which causes the loading of locahost:5021 to fail b/c there’s nothing in /build/...pug-stuff 

So the fix was to modify the run target to build after cleaning
```
build: clean copy-static-assets
        @$(WEBPACK)

// was `run: clean copy-static-assets`
run: build 
        @$(WEBPACK) serve & $(NODEMON) --watch ./src/server/ --watch ./src/shared/ -e ts --exec 'NODE_ENV=development ./scripts/startDevServer.sh'
```

- fix: update to webpack-dev-server@latest to fix broken localhost proxy

# Testing
- [x] Tried this on new repo `google-classroom-addon` and the `ark start -l` works and can load "Home" webpage


[FEE-220]: https://clever.atlassian.net/browse/FEE-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ